### PR TITLE
Updated For UNC Chapel Hill

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ These are the pre-fixed Resources you may use for University's Resources:
 
 + University of Illinois, Urbana–Champaign
 
++ University of North Carolina at Chapel Hill
+	- [all resources for public course listings](http://cs.unc.edu/academics/home-page-links/)
+
 + University of Waterloo
 
 


### PR DESCRIPTION
Rather than go by the (rather poor) practice of adding deprecated sites (I spied a "fall 2011" link above), I've added a link to the full public directory of courses at my school, which is updated every semester by the registrar.  So if a site goes dark and the link becomes bad (this issue will come up almost immediately), the registrar will handle it without creating bad links here.  Courses probably should not be listed individually in this way, rather, every school should submit it's own self-maintained directory. 

The resource I've added has more than 100 unique courses which would be futile to replicate here.  

This is a good idea, but you should also probably define a naming scheme.  You have "University of...." as well as "UC ___" which is shorthand for "University of California..."  and these will conflict.
